### PR TITLE
Fixed an issue with depth 1 which raised array negative index.

### DIFF
--- a/lib/marky_markov/markov_sentence_generator.rb
+++ b/lib/marky_markov/markov_sentence_generator.rb
@@ -82,6 +82,7 @@ class MarkovSentenceGenerator # :nodoc:
       word = weighted_random(sentence.last(@depth))
       if punctuation?(word)
         sentence[-1] = sentence.last.dup << word
+        sentence.concat(random_capitalized_word)
       elsif word.nil?
         sentence.concat(random_capitalized_word)
       else

--- a/spec/marky_markov/marky_markov_spec.rb
+++ b/spec/marky_markov/marky_markov_spec.rb
@@ -38,6 +38,16 @@ describe MarkyMarkov do
       sentence = dictionary.generate_10_words
       sentence.split.should have(10).words
     end
+
+    context "when using key depth of 1 word" do
+      let(:depth1dict) { MarkyMarkov::TemporaryDictionary.new(1) }
+      it "should not raise 'negative array size'" do
+        depth1dict.parse_string "short text. with many. full. stops."
+        lambda {
+          depth1dict.generate_15_words
+        }.should_not raise_error
+      end
+    end
   end
 
   context "PersistentDictionary" do


### PR DESCRIPTION
Hello. I have identified and fixed an issue with marky_markov.

In MarkovSentenceGenerator#generate, if you have key depth 1, when punctuation is encountered, you add the punctuation to the last word. This adds no new word, so it makes your word count short by 1. This results in array negative index at line 91.

You should be able to see this happen if you run spec without the fix in the generator.

Cheers,
Yuji Yokoo
