### PR TITLE
Depth flag and decluttering

### DIFF
--- a/bin/marky_markov
+++ b/bin/marky_markov
@@ -39,6 +39,12 @@ opt_parser = OptionParser.new do |opts|
     options[:resetdictionary] = true
   end
 
+  options[:depth] = 2
+  opts.on('-p', '--depth DEPTH',
+          'Use a chaining depth (integer, default 2 is recommended)') do |depth|
+    options[:depth] = depth.to_i
+  end
+
   opts.on('-h', '--help', 'Display this screen') do
     STDOUT.puts opt_parser
     exit
@@ -58,7 +64,7 @@ end
 case ARGV[0]
 when "speak"
   if options[:source]
-    markov = MarkyMarkov::TemporaryDictionary.new
+    markov = MarkyMarkov::TemporaryDictionary.new(options[:depth])
     begin markov.parse_file(options[:source])
     rescue MarkovDictionary::FileNotFoundError => err
       abort("Sorry, #{err}. I can't use it as a source.")
@@ -69,7 +75,7 @@ when "speak"
       STDERR.puts "Please build a dictionary with read or use the --source option to build a temporary dictionary."
       exit(false)
     end
-    markov = MarkyMarkov::Dictionary.new(options[:dictionary])
+    markov = MarkyMarkov::Dictionary.new(options[:dictionary], options[:depth])
   end
   STDOUT.puts markov.generate_n_sentences(options[:sentencecount])
 when "read"

--- a/lib/marky_markov/markov_dictionary.rb
+++ b/lib/marky_markov/markov_dictionary.rb
@@ -2,7 +2,6 @@
 class MarkovDictionary # :nodoc:
   attr_reader :dictionary, :depth, :capitalized_words
   def initialize(depth=2)
-    puts "Initialize"
     @dictionary = {}
     @capitalized_words = []
     @depth = depth

--- a/spec/marky_markov/marky_markov_spec.rb
+++ b/spec/marky_markov/marky_markov_spec.rb
@@ -124,6 +124,20 @@ describe MarkyMarkov do
       expect {emptydict.generate_10_sentences}.to raise_error(EmptyDictionaryError)
     end
 
+    context "when a depth is specified" do
+      let (:test_depth) { 4 }
+      let!(:dictionary) do |dict|
+        MarkyMarkov::Dictionary.new("spec/data/temptextdict", test_depth).tap do |d|
+          d.parse_file "spec/data/test.txt"
+        end
+      end
+
+      it "should correctly set the dictionary's depth field" do
+        expect(dictionary.instance_variable_get(:@dictionary)
+          .instance_variable_get(:@depth)).to eq(test_depth)
+      end
+    end
+
     after do
       PersistentDictionary.delete_dictionary!(dictionary)
     end


### PR DESCRIPTION
Hi! I was playing with this and made some changes for myself, you might like to include them:

Added -p as a flag to specify Markov chaining depth at command-line execution time.
Also removed a puts call so that output isn't cluttered during rspec testing, etc.