### PR TITLE
update readme to reflect markov.parse_string

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,11 @@ OR you can pass in a MarkyMarkov::Dictionary object directly.
 
     MarkyMarkov::Dictionary.delete_dictionary!(markov)
 
+## Train from a string
+
+If you want to add to your dictionary from a string instead of a file, easy!
+    
+    markov.parse_string "I hope this makes sense."
 
 # Command-Line Usage
 


### PR DESCRIPTION
I was playing with this and noticed that the parse_string was missing from the documentation, thought I'd add it in.

n